### PR TITLE
Search bar - more results

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import "@fontsource/roboto/400.css"; // Regular font weight
 import "@fontsource/roboto/500.css"; // Medium font weight
 import "@fontsource/roboto/700.css"; // Bold font weight
 import About from "./pages/About";
+import SearchResultsForInput from "./pages/SearchResultsForInput";
 
 function App() {
   return (
@@ -15,6 +16,7 @@ function App() {
       <Routes>
         <Route path="/" element={<Layout />}>
           <Route index element={<Dashboard />} />
+          <Route path="/search/:input" element={<SearchResultsForInput />} />
           <Route
             path="/list/:genericName"
             element={<ListOfDrugsByGenericName />}

--- a/src/api/searchDrugs.ts
+++ b/src/api/searchDrugs.ts
@@ -1,9 +1,9 @@
 import axios from "axios";
 
-export const searchDrug = async (query: string) => {
+export const searchDrug = async (query: string, limit: number) => {
   try {
     const response = await axios.get(
-      `https://api.fda.gov/drug/label.json?count=openfda.generic_name.exact&search=openfda.generic_name:*${query}*&limit=100`
+      `https://api.fda.gov/drug/label.json?count=openfda.generic_name.exact&search=openfda.generic_name:*${query}*&limit=${limit}`
     );
     return response.data.results;
   } catch (err) {

--- a/src/api/searchDrugs.ts
+++ b/src/api/searchDrugs.ts
@@ -2,9 +2,8 @@ import axios from "axios";
 
 export const searchDrug = async (query: string, limit: number) => {
   try {
-    const response = await axios.get(
-      `https://api.fda.gov/drug/label.json?count=openfda.generic_name.exact&search=openfda.generic_name:*${query}*&limit=${limit}`
-    );
+    const url = `https://api.fda.gov/drug/label.json?count=openfda.generic_name.exact&search=openfda.generic_name:*${query}*&limit=${limit}`;
+    const response = await axios.get(url);
     return response.data.results;
   } catch (err) {
     console.error(err);

--- a/src/components/Dashboard/SearchBar.tsx
+++ b/src/components/Dashboard/SearchBar.tsx
@@ -54,7 +54,7 @@ const SearchBar = () => {
   const handleOptionChange = (event: any, value: string) => {
     if (value && value === customOptionValue) {
       // if its a custom option used to see all options that start with the input value
-      const path = `/search/${inputValue}?page=1`;
+      const path = `/search/${inputValue}`;
       navigate(path);
     } else {
       // if its a fetched option

--- a/src/components/Dashboard/SearchBar.tsx
+++ b/src/components/Dashboard/SearchBar.tsx
@@ -14,7 +14,9 @@ const SearchBar = () => {
   const [inputValue, setInputValue] = useState("");
   const [error, setError] = useState(Boolean);
   const navigate = useNavigate();
+
   const fetchLimit = 20;
+  const customOptionValue = `See top searches starting with '${inputValue}'`;
 
   const fetchOptions = async (value: string) => {
     try {
@@ -50,9 +52,9 @@ const SearchBar = () => {
 
   // value can be an option IF the limit of options (20) was reached.
   const handleOptionChange = (event: any, value: string) => {
-    if (value && value === `See all searches starting with ${inputValue}`) {
+    if (value && value === customOptionValue) {
       // if its a custom option used to see all options that start with the input value
-      const path = `/bbb`;
+      const path = `/search/${inputValue}?page=1`;
       navigate(path);
     } else {
       // if its a fetched option
@@ -67,11 +69,10 @@ const SearchBar = () => {
   };
 
   const customOptions = [...options]; // Create a copy of options array
-
   /* If the options length === 20, lets add a new option to the end of the array,
   This option will be responsible to navigate to a different route and fetch without limits. */
   if (options.length === fetchLimit) {
-    customOptions.push(`See all searches starting with ${inputValue}`);
+    customOptions.push(customOptionValue);
   }
 
   return (

--- a/src/pages/ListOfDrugsByGenericName.tsx
+++ b/src/pages/ListOfDrugsByGenericName.tsx
@@ -61,7 +61,7 @@ const ListOfDrugsByGenericName = () => {
         {loading ? (
           <Skeleton width={300} />
         ) : (
-          `Total of ${count} searches conducted across various manufacturers.`
+          `Total of ${count} searches conducted across various brands and manufacturers.`
         )}
       </Typography>
       <Pagination

--- a/src/pages/SearchResultsForInput.tsx
+++ b/src/pages/SearchResultsForInput.tsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useState } from "react";
+import { Link, useLocation, useParams } from "react-router-dom";
+import { searchDrug } from "../api/searchDrugs";
+import { Box, CircularProgress, Typography } from "@mui/material";
+
+interface Drug {
+  openfda: {
+    generic_name: string;
+    spl_id: string;
+  };
+}
+
+const SearchResultsForInput = () => {
+  const [options, setOptions] = useState<any[]>([]);
+  const [loading, setLoading] = useState(true);
+  const { input } = useParams();
+
+  useEffect(() => {
+    const getFullData = async () => {
+      try {
+        if (typeof input === "string") {
+          setLoading(true);
+          const drugsData = await searchDrug(input, 100);
+          if (drugsData) {
+            setOptions(drugsData);
+          } else {
+            setOptions([]);
+          }
+        }
+      } catch (err) {
+      } finally {
+        setLoading(false);
+      }
+    };
+    getFullData();
+  }, []);
+
+  if (loading) {
+    return <CircularProgress sx={{ display: "grid", alignSelf: "center" }} />;
+  }
+
+  return (
+    <Box>
+      {options.length > 0 && (
+        <>
+          <Typography variant="h6" marginBottom={5}>
+            Top 100 seach results for '{input}'.
+          </Typography>
+          <Box display={"flex"} flexDirection={"column"} gap={4}>
+            {options.map((option) => (
+              <Typography key={option.term}>
+                <Link
+                  to={`/list/${option.term}`}
+                  style={{ wordBreak: "break-word" }}
+                >
+                  {option.term}
+                </Link>
+              </Typography>
+            ))}
+          </Box>
+        </>
+      )}
+    </Box>
+  );
+};
+
+export default SearchResultsForInput;


### PR DESCRIPTION
This update enhances the search bar functionality by adding a custom option for users to view the top 100 search results. The search bar fetches a maximum of 20 results. If the number of fetched results reaches this limit (i.e., options.length === 20), a custom option is created. This option displays "See top searches starting with '${inputValue}'" based on the user's input value. Clicking this custom option navigates the user to a new route called 'search', which takes the input value as a parameter and fetches the top 100 results that start with the input value.

Changes Made:

- Limited the search bar to fetch a maximum of 20 results.

- Added logic to detect when the fetched results reach the limit of 20.

- Implemented a custom option that appears when the limit is reached, displaying "See top searches starting with '${inputValue}'".

- Configured the custom option to navigate users to a new 'search' route.

- Created the 'search' route to accept the input value as a parameter and fetch the top 100 results starting with that input value.